### PR TITLE
Preinstall script fixed: -p parameters does not work on Windows machi…

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "babel src/OpenWeatherMap.js --out-file lib/index.js",
     "example": "babel-node example.js",
-    "preinstall": "mkdir -p lib",
+    "preinstall": "mkdir lib",
     "prepublish": "npm run build",
     "test": "jest --coverage"
   },


### PR DESCRIPTION
`mkdir -p lib`

Fails on windows machines.